### PR TITLE
Use site.baseurl in nav.html.

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,15 +1,15 @@
 
-<h1 class="page-title"><a href="https://pages.18f.gov/ED-Developer-Hub/">ED API docs</a></h1>
+<h1 class="page-title"><a href="{{ site.baseurl }}">ED API docs</a></h1>
       <p class="intro">Making the agency accessible to developers</p>
     <nav>    
         <ul>
-          <li><a href="https://pages.18f.gov/ED-Developer-Hub/" class="overview">Overview</a></li>
-          <li><a href="https://pages.18f.gov/ED-Developer-Hub/basics/" class="basics">API Basics</a></li>
-          <li><a href="https://pages.18f.gov/ED-Developer-Hub/details/" class="basics">API Details</a></li>
-          <li><a href="https://pages.18f.gov/ED-Developer-Hub/api-key/" class="basics">API Keys</a></li>
-          <li><a href="https://pages.18f.gov/ED-Developer-Hub/gallery/" class="basics">App Gallery</a></li>
-          <li><a href="https://pages.18f.gov/ED-Developer-Hub/other-resources/" class="queries">Other Resources</a></li>
+          <li><a href="{{ site.baseurl }}" class="overview">Overview</a></li>
+          <li><a href="{{ site.baseurl }}basics/" class="basics">API Basics</a></li>
+          <li><a href="{{ site.baseurl }}details/" class="basics">API Details</a></li>
+          <li><a href="{{ site.baseurl }}api-key/" class="basics">API Keys</a></li>
+          <li><a href="{{ site.baseurl }}gallery/" class="basics">App Gallery</a></li>
+          <li><a href="{{ site.baseurl }}other-resources/" class="queries">Other Resources</a></li>
           <li><a href="https://github.com/18F/ED-Developer-Hub/issues" class="queries">Feedback</a></li>
-          <li><a href="https://pages.18f.gov/ED-Developer-Hub/contact/" class="basics">Get In Touch</a></li>
+          <li><a href="{{ site.baseurl }}contact/" class="basics">Get In Touch</a></li>
         </ul>
     </nav>


### PR DESCRIPTION
The absolute URL to https://pages.18f.gov/ED-Developer-Hub/ is hard-coded into the links on the nav, which makes it particularly hard to navigate around one's local development deployment (it will also make it hard to have dev/staging deploys in the future, if they're desired).

This changes the nav area so we use `{{ site.baseurl }}` instead of hard-coding it.

There are lots of other places that the base URL is hard-coded; this just fixes the most acute pain points for development.