### PR TITLE
Fix site.baseurl typo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,6 @@ name: Department of Education - API Docs
 markdown: kramdown
 pygments: true
 safe: true
-baseurl: /ED-Developer-Hub/
+baseurl: /ED-Developer-Hub
 exclude: ['.ruby-version', 'node_modules', 'package.json', 'bower.json']
 swaggerurl: https://autoapi-ed.apps.cloud.gov/swagger/

--- a/_layouts/swagger-ui.html
+++ b/_layouts/swagger-ui.html
@@ -5,22 +5,22 @@
 <head>
   {% include head.html %}
 
-  <link href='{{ site.baseurl }}static/vendor/swagger-ui/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='{{ site.baseurl }}/static/vendor/swagger-ui/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
 
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/object-assign-pollyfill.js' type='text/javascript'></script>
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/jquery.slideto.min.js' type='text/javascript'></script>
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/jquery.wiggle.min.js' type='text/javascript'></script>
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/handlebars-4.0.5.js' type='text/javascript'></script>
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/lodash.min.js' type='text/javascript'></script>
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/backbone-min.js' type='text/javascript'></script>
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/swagger-ui.js' type='text/javascript'></script>
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/jsoneditor.min.js' type='text/javascript'></script>
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/marked.js' type='text/javascript'></script>
-  <script src='{{ site.baseurl }}static/vendor/swagger-ui/lib/swagger-oauth.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/lib/object-assign-pollyfill.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/lib/jquery.slideto.min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/lib/jquery.wiggle.min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/lib/handlebars-4.0.5.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/lib/lodash.min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/lib/backbone-min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/swagger-ui.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/lib/jsoneditor.min.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/lib/marked.js' type='text/javascript'></script>
+  <script src='{{ site.baseurl }}/static/vendor/swagger-ui/lib/swagger-oauth.js' type='text/javascript'></script>
 
   <style>
     html .swagger-section .swagger-ui-wrap {


### PR DESCRIPTION
Our `_config.yml` sets `baseurl` to a path with a `/` at the end, but `baseurl` isn't supposed to have it at the end, and indeed 18f-pages sets it to a value that doesn't have one at the end.  This means that the swagger-ui code which assumed it had a `/` at the end was suddenly smooshing together two directory names, resulting in broken URLs.

This fixes that!